### PR TITLE
fix error thrown for string interpolated keys

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -85,8 +85,9 @@ class AlphabetizeKeys
     node.properties.forEach (property) =>
       keyNode = @_getPropertyValueNode property, astApi
       key = keyNode.base.value
-      key = keyNode.properties[0].name.value if key is 'this'
-      keys.push key
+      if key
+        key = keyNode.properties[0].name.value if key is 'this'
+        keys.push key
 
     @_lintNodeKeys node, astApi, keys
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -84,10 +84,10 @@ class AlphabetizeKeys
 
     node.properties.forEach (property) =>
       keyNode = @_getPropertyValueNode property, astApi
+      return if keyNode.base.isComplex()
       key = keyNode.base.value
-      if key
-        key = keyNode.properties[0].name.value if key is 'this'
-        keys.push key
+      key = keyNode.properties[0].name.value if key is 'this'
+      keys.push key
 
     @_lintNodeKeys node, astApi, keys
 

--- a/src/index_spec.coffee
+++ b/src/index_spec.coffee
@@ -55,6 +55,14 @@ alphabetical =
   destructObjectArgument: 'fn = ({keyA, keyB, keyC}) ->'
   destructObjectAssignment: '{keyA, keyB, keyC} = object'
   destructObjectAssignmentWithThis: '{keyA, @keyB, keyC} = object'
+  # coffeelint: disable=no_interpolation_in_single_quotes
+  objectWithInterpolatedKeys: '''
+    object =
+      keyB: 2
+      "#{keyA}": 1
+      keyC: 3
+  '''
+  # coffeelint: enable=no_interpolation_in_single_quotes
 
 
 notAlphabetical =
@@ -119,15 +127,6 @@ notAlphabetical =
   destructObjectAssignment: '{keyC, keyB, keyA} = object'
   destructObjectAssignmentWithThis: '{keyC, @keyB, keyA} = object'
 
-# coffeelint: disable=no_interpolation_in_single_quotes
-objectWithInterpolatedKeys = '''
-  object =
-    keyB: 2
-    "#{keyA}": 1
-    keyC: 3
-'''
-# coffeelint: enable=no_interpolation_in_single_quotes
-
 describe 'alphabetize_keys', ->
   before ->
     coffeelint.registerRule AlphabetizeKeys
@@ -146,7 +145,3 @@ describe 'alphabetize_keys', ->
           errors = coffeelint.lint notAlphabetical[name]
           expect(errors).to.have.lengthOf 1
           expect(errors[0].rule).to.eql 'alphabetize_keys'
-
-  it 'it ignores keys that are string interpolated', ->
-    errors = coffeelint.lint objectWithInterpolatedKeys
-    expect(errors).to.be.empty

--- a/src/index_spec.coffee
+++ b/src/index_spec.coffee
@@ -119,6 +119,14 @@ notAlphabetical =
   destructObjectAssignment: '{keyC, keyB, keyA} = object'
   destructObjectAssignmentWithThis: '{keyC, @keyB, keyA} = object'
 
+# coffeelint: disable=no_interpolation_in_single_quotes
+objectWithInterpolatedKeys = '''
+  object =
+    keyB: 2
+    "#{keyA}": 1
+    keyC: 3
+'''
+# coffeelint: enable=no_interpolation_in_single_quotes
 
 describe 'alphabetize_keys', ->
   before ->
@@ -138,3 +146,7 @@ describe 'alphabetize_keys', ->
           errors = coffeelint.lint notAlphabetical[name]
           expect(errors).to.have.lengthOf 1
           expect(errors[0].rule).to.eql 'alphabetize_keys'
+
+  it 'it ignores keys that are string interpolated', ->
+    errors = coffeelint.lint objectWithInterpolatedKeys
+    expect(errors).to.be.empty

--- a/src/index_spec.coffee
+++ b/src/index_spec.coffee
@@ -127,6 +127,7 @@ notAlphabetical =
   destructObjectAssignment: '{keyC, keyB, keyA} = object'
   destructObjectAssignmentWithThis: '{keyC, @keyB, keyA} = object'
 
+
 describe 'alphabetize_keys', ->
   before ->
     coffeelint.registerRule AlphabetizeKeys


### PR DESCRIPTION
@charlierudolph 

Came across a case where objects with string interpolated keys throw an error, since the key is an expression and not a value. Since string interpolation can get quite complicated (`"foo#{bar}baz#{quz}": 1`) I figured it might be better to just ignore them.

What are you thoughts?
