### PR TITLE
Fix config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Put this in your coffeelint config:
 
 ```json
 "alphabetize_keys": {
-  "module": "coffeelint-alphabetize-keys",
+  "module": "coffeelint-alphabetize-keys"
 }
 ```
 


### PR DESCRIPTION
Noticed a trailing comma in the config example, which prevents me from
copy / pasting to run this module
